### PR TITLE
Nesthdb

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,63 @@
       "--child-limit","5"
     ]
   },
+  "problem_specific": {
+    "nestpmc": {
+      "max_solver_threads": 4,
+      "inner_vars_threshold": 10,
+      "max_worker_threads": 4
+    }
+  },
   "dpdb": {
-    "max_worker_threads": 24
-  }
+  },
+	"nesthdb": {
+		"threshold_hybrid" : 45,
+		"threshold_abstract" : 8,
+		"max_recursion_depth" : 1,
+		"sat_solver": {
+			"path": "/home/rafael/projects/dp_on_dbs/picosat-965/picosat",
+			"seed_arg": "-s"
+		},
+		"sharpsat_solver": {
+			"path": "/home/rafael/projects/miniC2D2/bin/linux/miniC2D",
+			"args": "-C -c",
+			"output_parser": {
+				"class": "RegExReader",
+				"args": {
+					"pattern": "Counting... (\\d+) models"
+				},
+				"result":"result"
+			}
+		},
+        "preprocessor": {
+            "path": "./pmc_linux",
+	        "args": "-vivification -eliminateLit -litImplied -iterate=10"
+        },
+        "alt_preprocessor": {
+            "path": "../Riss/coprocessor",
+            "args": "-enabled_cp3 -up -subsimp -bve -no-bve_gates -no-bve_strength -bve_red_lits=1 -cp3_bve_heap=1 -bve_heap_updates=1 -bve_totalG -bve_cgrow_t=1000 -bve_cgrow=10"
+        },
+		"pmc_solver": {
+			"path": "/home/rafael/projects/g2/build/ganak",
+			"output_parser": {
+				"class": "RegExReader",
+				"args": {
+					"pattern": "s pmc (\\d+)"
+				},
+				"result":"result"
+			}
+		},
+		"asp": {
+			"encodings": [{ 
+				"file": "./guess_min_degree.lp",
+				"size": 95,
+				"timeout": 10
+			},
+			{ 
+				"file": "./guess_increase.lp",
+				"size": 64,
+				"timeout" : 35
+			}]
+		}
+	}
 }

--- a/dpdb/problem.py
+++ b/dpdb/problem.py
@@ -186,7 +186,6 @@ class Problem(object):
             sel_list += "{}{}".format(", " if sel_list else "", ",".join(extra_cols))
 
         candidates_sel = self.candidates_select(node)
-
         if self.candidate_store == "cte":
             q = f"WITH candidate AS ({candidates_sel}) SELECT {sel_list} FROM candidate"
         elif self.candidate_store == "subquery":

--- a/dpdb/problems/nestpmc.py
+++ b/dpdb/problems/nestpmc.py
@@ -65,7 +65,7 @@ class NestPmc(Problem):
             extra_proj = []
         q = ""
 
-        if any(node.needs_introduce(v) for v in node.vertices):
+        if any(node.needs_introduce(v) for v in node.vertices + extra_proj):
             q += "WITH introduce AS ({}) ".format(self.introduce(node))
 
         q += "SELECT {}".format(

--- a/dpdb/reader.py
+++ b/dpdb/reader.py
@@ -159,6 +159,12 @@ class CnfReader(DimacsReader):
         else:
             self.num_vars = int(self._problem_vars[0])
             self.num_clauses = int(self._problem_vars[1])
+            if self.num_vars == 0:
+                self.models = 0
+                self.maybe_sat = False
+                if not self.silent:
+                    logger.info("Problem has 0 models (solved by pre-processing)")
+                self.done = True
 
     def read_terminated(self, lines, line, lineno):
         i = 1
@@ -182,7 +188,6 @@ class CnfReader(DimacsReader):
         
         maxvar = 0
         #projected_vars = set()
-
         for lineno, line in enumerate(lines):
             if not line or self.is_comment(line):
                 continue
@@ -241,7 +246,10 @@ class CnfReader(DimacsReader):
 
         for clause in self.clauses:
             self.vars.update([abs(lit) for lit in clause])
-        maxvar = max(maxvar,max(self.vars))
+        if len(self.vars) == 0:
+            maxvar = 0
+        else:
+            maxvar = max(maxvar,max(self.vars))
 
         self.single_vars = set((abs(l) for l in self.single_clauses))
         self.projected = self.projected.difference(self.single_vars)


### PR DESCRIPTION
- change to config.json is usefull but not necessary I think. I could change it to contain blanks instead of my specific solvers.
- change to dp/reader.py can not hurt and is necessary for using preprocessors that are different from pmc
- change to dpdb/problems/nesthdb.py is necessary: in case the number of variables was low enough to use only DB techniques the extra variables were not considered in the check whether they need to be introduced.
- change to nesthdb.py can not hurt and allows the usage of coprocessor as a secondary preprocessor that does current state of the art preprocessing for the SAT part of PMC.